### PR TITLE
Remove bogus log messages and add cache for 2LO

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ REQUIRED_PACKAGES = [
     'oauth2client>=2.1.0',
     'setuptools>=18.5',
     'six>=1.9.0',
+    'fasteners>=0.14.1'
 ]
 
 TESTING_PACKAGES = [

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ envlist = py27,py34,py35,cover
 deps =
     mock
     nose
+    fasteners
 commands =
     nosetests []
 passenv = TRAVIS*
@@ -17,6 +18,7 @@ commands =
 deps =
     mock
     nose
+    fasteners
     coverage
     nosexcover
 


### PR DESCRIPTION
1. Remove the bogus log messages generated by the old multistore_file module by switching to multiprocess_file_storage module.
2. Add cache for getting 2LO token by using the same multiprocess_file_storage module.