### PR TITLE
Add reset command

### DIFF
--- a/oauth2l/__init__.py
+++ b/oauth2l/__init__.py
@@ -342,6 +342,10 @@ def _Info(args):
     else:
         print(_CompactJson(tokeninfo))
 
+def _Reset(args):
+    credentials_filename = _GetCredentialsFilename(args.credentials_filename)
+    if os.path.exists(credentials_filename):
+      os.remove(credentials_filename)
 
 def _Test(args):
     """Test an access token. Exits with 0 if valid, 1 otherwise."""
@@ -388,6 +392,11 @@ def _GetParser():
         'scope',
         nargs='*',
         help='Scope to header. May be provided multiple times.')
+
+    # reset
+    reset = subparsers.add_parser('reset', help=_Reset.__doc__,
+                                   parents=[shared_flags])
+    reset.set_defaults(func=_Reset)
 
     # info
     info = subparsers.add_parser('info', help=_Info.__doc__,

--- a/oauth2l/oauth2l_test.py
+++ b/oauth2l/oauth2l_test.py
@@ -335,6 +335,39 @@ class TestOtherCommands(unittest.TestCase):
             self.assertEqual(1, mock_http.call_count)
             self.assertEqual(1, mock_h.request.call_count)
 
+    def testReset(self):
+        orig_os_remove = os.remove
+        orig_os_path_exist = os.path.exists
+        os.remove = mock_remove = mock.MagicMock()
+        os.path.exists = mock_exists = mock.MagicMock()
+        mock_exists.return_value = True
+        output = _GetCommandOutput('reset', [])
+        mock_remove.assert_called_once_with(os.path.expanduser('~/.oauth2l.token'))
+        os.remove = orig_os_remove
+        os.path.exists = orig_os_path_exist
+
+    def testResetFileNotExist(self):
+        orig_os_remove = os.remove
+        orig_os_path_exist = os.path.exists
+        os.remove = mock_remove = mock.MagicMock()
+        os.path.exists = mock_exists = mock.MagicMock()
+        mock_exists.return_value = False
+        output = _GetCommandOutput('reset', []) 
+        mock_remove.assert_not_called()
+        os.remove = orig_os_remove
+        os.path.exists = orig_os_path_exist
+
+    def testResetWithFilename(self):
+        orig_os_remove = os.remove
+        orig_os_path_exist = os.path.exists
+        os.remove = mock_remove = mock.MagicMock()
+        os.path.exists = mock_exists = mock.MagicMock()
+        mock_exists.return_value = True
+        output = _GetCommandOutput('reset', ['--credentials_filename', '~/my_oauth_token'])
+        mock_remove.assert_called_once_with(os.path.expanduser('~/my_oauth_token'))
+        os.remove = orig_os_remove
+        os.path.exists = orig_os_path_exist
+
 
 class TestServiceAccounts(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
The reset command removes the local credential cache file.
Example usage:
$ oauth2l reset