### PR TITLE
Use URIs in provided json instead of default one.

### DIFF
--- a/oauth2l/__init__.py
+++ b/oauth2l/__init__.py
@@ -101,12 +101,7 @@ def GetClientInfoFromFile(client_secrets):
         client_secrets = json.load(client_secrets_file)
     if 'installed' not in client_secrets:
         raise ValueError('Provided client ID must be for an installed app')
-    client_secrets = client_secrets['installed']
-    return {
-        'client_id': client_secrets['client_id'],
-        'client_secret': client_secrets['client_secret'],
-        'user_agent': _DEFAULT_USER_AGENT,
-    }
+    return client_secrets['installed']
 
 
 def _ExpandScopes(scopes):


### PR DESCRIPTION
For both service account secret and client secret, there are URIs such as token_uri, auth_uri in the token. We should use whatever provided in the token instead of default to production oauth2 addresses.