### PR TITLE
Fix packaging and test setup.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,13 @@
+[run]
+branch = True
+
+[report]
+omit =
+    */conftest.py
+exclude_lines =
+    # Re-enable the standard pragma
+    pragma: NO COVER
+    # Ignore debug-only repr
+    def __repr__
+    # Don't complain if tests don't hit defensive assertion code:
+    raise NotImplementedError

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ distribute-*
 # Test files
 .tox/
 nosetests.xml
+.cache/
 
 # Coverage related
 .coverage

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,2 @@
-include *.py
-include *.txt
-include *.md
-recursive-include oauth2l *.py
+include README.md LICENSE.txt
+recursive-include oauth2l *.json

--- a/oauth2l/__init__.py
+++ b/oauth2l/__init__.py
@@ -73,6 +73,7 @@ from oauth2client import GOOGLE_TOKEN_INFO_URI
 from oauth2client import service_account
 from oauth2client import tools
 from oauth2client.contrib import multiprocess_file_storage
+import pkg_resources
 
 # We could use a generated client here, but it's used for precisely
 # one URL, with one parameter and no worries about URL encoding. Let's
@@ -83,7 +84,7 @@ _OAUTH2_TOKENINFO_TEMPLATE = (
 
 # Keep in sync with setup.py. (Currently just used for UserAgent
 # tagging, so not critical.)
-_OAUTH2L_VERSION = '1.0.0'
+_OAUTH2L_VERSION = pkg_resources.get_distribution('google-oauth2l').version
 _DEFAULT_USER_AGENT = 'oauth2l/' + _OAUTH2L_VERSION
 # Prefix of Google OAuth scopes
 _SCOPE_PREFIX = 'https://www.googleapis.com/auth/'

--- a/oauth2l/oauth2l_test.py
+++ b/oauth2l/oauth2l_test.py
@@ -181,7 +181,7 @@ class TestFetch(unittest.TestCase):
             self.credentials.access_token = "refreshed_credentials"
         mock_refresh.side_effect = refreshCredentials
         self.credentials.access_token = None
-        self.credentials.access_token_expired = False
+        self.credentials.token_expiry = None
         output = _GetCommandOutput('fetch',
                                    self.json_args + ['userinfo.email'])
 
@@ -198,7 +198,7 @@ class TestFetch(unittest.TestCase):
             self.credentials.access_token = "refreshed_credentials"
         mock_refresh.side_effect = refreshCredentials
         self.credentials.access_token = "some_token"
-        self.credentials.access_token_expired = True
+        self.credentials.token_expiry = None
         output = _GetCommandOutput('fetch',
                                    self.json_args + ['userinfo.email'])
 
@@ -295,7 +295,7 @@ class TestOtherCommands(unittest.TestCase):
         scopes = [u'https://www.googleapis.com/auth/userinfo.email',
                   u'https://www.googleapis.com/auth/cloud-platform']
         content = json.dumps({'scope': ' '.join(scopes)})
-        if isinstance(content, bytes):
+        if isinstance(content, bytes):  # pragma: NO COVER
             content = content.decode('utf8')
         with mock.patch.object(httplib2, 'Http', autospec=True) as mock_http:
             mock_http.return_value = mock_h = mock.MagicMock()

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal = 1

--- a/setup.py
+++ b/setup.py
@@ -14,20 +14,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""oauth2l configuration."""
+import io
 
-import platform
-
-try:
-    import setuptools
-except ImportError:
-    from ez_setup import use_setuptools
-    use_setuptools()
-    import setuptools
+from setuptools import find_packages
+from setuptools import setup
 
 # Configure the required packages and scripts to install, depending on
 # Python version and OS.
-REQUIRED_PACKAGES = [
+DEPENDENCIES = [
     'httplib2>=0.9.1',
     'oauth2client>=2.1.0',
     'setuptools>=18.5',
@@ -35,41 +29,25 @@ REQUIRED_PACKAGES = [
     'fasteners>=0.14.1'
 ]
 
-TESTING_PACKAGES = [
-    'mock>=1.0.1',
-]
-
 CONSOLE_SCRIPTS = [
     'oauth2l = oauth2l:main',
 ]
 
-py_version = platform.python_version()
+with io.open('README.md', 'r') as fh:
+    README = fh.read()
 
-if py_version < '2.7' or ('3' < py_version < '3.4'):
-    raise ValueError('oauth2l requires Python 2.7 or 3.4+')
-
-# Keep in sync with oauth2l/__init__.py.
-_OAUTH2L_VERSION = '1.0.0'
-
-with open('README.md') as fileobj:
-    README = fileobj.read()
-
-setuptools.setup(
+setup(
     name='google-oauth2l',
-    version=_OAUTH2L_VERSION,
+    version='1.0.0',
     description='command-line google oauth tools',
     long_description=README,
     url='http://github.com/google/oauth2l',
     author='Craig Citro',
     author_email='craigcitro@google.com',
     # Contained modules and scripts.
-    packages=setuptools.find_packages(),
+    packages=find_packages(),
     entry_points={'console_scripts': CONSOLE_SCRIPTS},
-    install_requires=REQUIRED_PACKAGES,
-    tests_require=REQUIRED_PACKAGES + TESTING_PACKAGES,
-    extras_require={
-        'testing': TESTING_PACKAGES,
-    },
+    install_requires=DEPENDENCIES,
     # PyPI package information.
     classifiers=[
         'License :: OSI Approved :: Apache Software License',

--- a/tox.ini
+++ b/tox.ini
@@ -4,23 +4,20 @@ envlist = py27,py34,py35,cover
 [testenv]
 deps =
     mock
-    nose
-    fasteners
+    pytest
+    pytest-cov
 commands =
-    nosetests []
+    pytest {posargs:oauth2l}
 passenv = TRAVIS*
 
 [testenv:cover]
 basepython =
     python2.7
 commands =
-    nosetests --with-xunit --with-xcoverage --cover-package=oauth2l --nocapture --cover-erase --cover-tests --cover-branches []
+    py.test --cov=oauth2l --cov-report= {posargs:oauth2l}
+    coverage report --show-missing --fail-under=100
 deps =
-    mock
-    nose
-    fasteners
-    coverage
-    nosexcover
+  {[testenv]deps}
 
 [testenv:coveralls]
 basepython = {[testenv:cover]basepython}


### PR DESCRIPTION
* Setuptools is available in every modern python environment, no need to fall back to ez_setup (which is abandoned).
* Use io.open instead of open.
* Remove tests_requires, as it doesn't do anything.
* Use pytest instead of the unmaintained nosetests.
* Use coveragerc instead of arguments to the test function.
* Add setup.cfg to allow distribution as a universal wheel.
* Single-source the version number using pkg_resources.
* Fix broken tests.
* Fix manifest to properly include test resources.