### PR TITLE
Switch the Golang tool to use the new Google Authenticator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ htmlcov/
 
 # Make sure a generated file isn't accidentally committed.
 reduced.pylintrc
+
+# GoLand
+go/.idea/


### PR DESCRIPTION
TODOs:
 1. Update the tool interface to be the same as the Python one.
 2. Deprecate go/oauth2l/oauth2client
 3. Deprecate the python tool.