### PR TITLE
Added default auth & token URLs instead from the wellknownfile

### DIFF
--- a/go/sgauth/README.md
+++ b/go/sgauth/README.md
@@ -66,6 +66,10 @@ need to specify the `scope` value.
 will try to look for your service account JSON file at the default path --- the path specified
 by the `$GOOGLE_APPLICATION_CREDENTIAL` environment variable.
 
+- __Authorized User__: If no above conditions are defined and you can still auth to google by genearating
+ADC with command `gcloud auth application-default login`. This will store ADC at wellknown path 
+`~/.config/gcloud/application_default_credentials.json`
+
 Protocols
 ---------
 

--- a/go/sgauth/credentials/file.go
+++ b/go/sgauth/credentials/file.go
@@ -23,6 +23,9 @@ import (
 // DefaultTokenURL is Google's OAuth 2.0 token URL to use with the JWT flow.
 const DefaultTokenURL = "https://accounts.google.com/o/oauth2/token"
 
+// DefaultAuthURL is Google's OAuth 2.0 Auth URL to use with the 2LO flow.
+const DefaultAuthURL = "https://accounts.google.com/o/oauth2/auth"
+
 // JSON key file types.
 const (
 	ServiceAccountKey  = "service_account"
@@ -90,8 +93,8 @@ func (f *File) TokenSource(ctx context.Context, scopes []string,
 			ClientSecret: f.ClientSecret,
 			Scopes:       scopes,
 			Endpoint:     internal.Endpoint{
-				AuthURL: f.AuthURL,
-				TokenURL: f.TokenURL,
+				AuthURL: DefaultAuthURL,
+				TokenURL: DefaultTokenURL,
 			},
 		}
 		tok := &internal.Token{RefreshToken: f.RefreshToken}

--- a/go/sgauth/credentials/file.go
+++ b/go/sgauth/credentials/file.go
@@ -88,13 +88,22 @@ func (f *File) TokenSource(ctx context.Context, scopes []string,
 		cfg := JWTConfigFromFile(f, scopes)
 		return cfg.TokenSource(ctx), nil
 	case UserCredentialsKey:
+		authURL := f.AuthURL
+		tokenURL := f.TokenURL
+		// Falling back to default URLs only if file URLs are empty
+		if authURL == "" {
+			authURL = DefaultAuthURL
+		}
+		if tokenURL == "" {
+			tokenURL = DefaultTokenURL
+		}
 		cfg := &internal.Config{
 			ClientID:     f.ClientID,
 			ClientSecret: f.ClientSecret,
 			Scopes:       scopes,
 			Endpoint:     internal.Endpoint{
-				AuthURL: DefaultAuthURL,
-				TokenURL: DefaultTokenURL,
+				AuthURL: authURL,
+				TokenURL: tokenURL,
 			},
 		}
 		tok := &internal.Token{RefreshToken: f.RefreshToken}


### PR DESCRIPTION
* 2LO flow is not working with ~/.config/gcloud/application_default_credentials.json as it doenst contain fields token_uri & auth_uri
* So pointing them to default URLs