### PR TITLE
Fix Installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,10 +52,10 @@ https://github.com/golang/go/wiki/GOPATH))
 
 ```bash
 # Get the package from Github
-$ go get github.com/google/oauth2l/go/oauth2l
+$ go get github.com/google/oauth2l
 
 # Install the package into your $GOPATH/bin/
-$ go install github.com/google/oauth2l/go/oauth2l
+$ go install github.com/google/oauth2l
 
 # Fetch the access token from your credentials with cloud-platform scope
 $ ~/go/bin/oauth2l fetch --json ~/your_credentials.json cloud-platform

--- a/sgauth/settings.go
+++ b/sgauth/settings.go
@@ -41,6 +41,9 @@ type Settings struct {
 	// A user specified project that is responsible for the request quota and
 	// billing charges.
 	QuotaProject string
+	// IAM context attributes
+	// UNIMPLEMENTED
+	IAMAuthToken string
 	// End-user OAuth Flow handler that redirects the user to the given URL
 	// and returns the token.
 	OAuthFlowHandler func(url string) (token string, err error)


### PR DESCRIPTION
Update README since `go` directory no longer exists.
Reintroduce `IAMAuthToken string` since it is still referenced by some code.
