### PR TITLE
Add test-www.sandbox.googleapis.com into whitelist

### DIFF
--- a/sgauth/internal/token_retriever.go
+++ b/sgauth/internal/token_retriever.go
@@ -158,7 +158,6 @@ func retrieveToken(ctx context.Context, clientID, clientSecret, tokenURL string,
 			v.Set("client_secret", clientSecret)
 		}
 	}
-
 	req, err := http.NewRequest("POST", tokenURL, strings.NewReader(v.Encode()))
 	if err != nil {
 		return nil, err

--- a/sgauth/internal/token_retriever.go
+++ b/sgauth/internal/token_retriever.go
@@ -92,6 +92,7 @@ var brokenAuthHeaderProviders = []string{
 	"https://openapi.baidu.com/",
 	"https://slack.com/",
 	"https://test-sandbox.auth.corp.google.com",
+	"https://test-www.sandbox.googleapis.com",
 	"https://test.salesforce.com/",
 	"https://user.gini.net/",
 	"https://www.douban.com/",
@@ -157,6 +158,7 @@ func retrieveToken(ctx context.Context, clientID, clientSecret, tokenURL string,
 			v.Set("client_secret", clientSecret)
 		}
 	}
+
 	req, err := http.NewRequest("POST", tokenURL, strings.NewReader(v.Encode()))
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
test-www.sandbox.googleapis.com server does not implement the OAuth 2.0 spec fully so we need to add it into the whitelist for special handling.

For more details please read https://code.google.com/p/goauth2/issues/detail?id=31