### PR TITLE
Fix build tag

### DIFF
--- a/sgauth/appengine_hook.go
+++ b/sgauth/appengine_hook.go
@@ -14,6 +14,7 @@
 // limitations under the License.
 //
 // +build appengine appenginevm
+
 package sgauth
 
 import "google.golang.org/appengine"


### PR DESCRIPTION
'go vet' detects the error in the existing version

./appengine_hook.go:15: +build comment must appear before package clause
and be followed by a blank line

Without this fix, this hook is pulled in for all builds, and causes the tool to behave as if it's running on AppEngine all the time.