### PR TITLE
use GuessUnixHomeDir in cacheLocation

### DIFF
--- a/sgauth/default.go
+++ b/sgauth/default.go
@@ -140,10 +140,10 @@ func wellKnownFile() string {
 	if runtime.GOOS == "windows" {
 		return filepath.Join(os.Getenv("APPDATA"), "gcloud", f)
 	}
-	return filepath.Join(guessUnixHomeDir(), ".config", "gcloud", f)
+	return filepath.Join(GuessUnixHomeDir(), ".config", "gcloud", f)
 }
 
-func guessUnixHomeDir() string {
+func GuessUnixHomeDir() string {
 	// Prefer $HOME over user.Current due to glibc bug: golang.org/issue/13470
 	if v := os.Getenv("HOME"); v != "" {
 		return v

--- a/util/cache.go
+++ b/util/cache.go
@@ -20,7 +20,7 @@ import (
 	"encoding/json"
 	"os"
 	"github.com/google/oauth2l/sgauth"
-	"os/user"
+	"path/filepath"
 )
 
 const (
@@ -113,11 +113,7 @@ func loadCache() (map[string][]byte, error) {
 }
 
 func cacheLocation() string {
-	usr, err := user.Current()
-	if err != nil {
-		log.Fatal( err )
-	}
-	return usr.HomeDir + "/" + cacheFileName
+	return filepath.Join(sgauth.GuessUnixHomeDir(), cacheFileName)
 }
 
 func createKey(settings *sgauth.Settings) CacheKey {


### PR DESCRIPTION
This allows redirecting the location of the cache file via the `HOME` environment variable. Without this, the location cannot be changed by users. I'm not sure sgauth/default.go is still the preferred location for `GuessUnixHomeDir`, but I didn't want to introduce too many changes.