### PR TITLE
Allow greater control over caching

### DIFF
--- a/main.go
+++ b/main.go
@@ -82,7 +82,7 @@ func main() {
 	jwtFlag := flagSet.Bool("jwt", false, "Use JWT auth flow")
 	ssoFlag := flagSet.Bool("sso", false, "Use SSO auth flow")
 	ssocli := flagSet.String("ssocli", "", "Path to SSO CLI")
-	flagSet.StringVar(&util.CacheLocation, "cache", util.CacheLocation, "Path to the credential cache file.")
+	flagSet.StringVar(&util.CacheLocation, "cache", util.CacheLocation, "Path to the credential cache file. Disables caching if set to empty.")
 
 	if len(os.Args) < 2 {
 		help(flagSet)

--- a/main.go
+++ b/main.go
@@ -82,6 +82,7 @@ func main() {
 	jwtFlag := flagSet.Bool("jwt", false, "Use JWT auth flow")
 	ssoFlag := flagSet.Bool("sso", false, "Use SSO auth flow")
 	ssocli := flagSet.String("ssocli", "", "Path to SSO CLI")
+	flagSet.StringVar(&util.CacheLocation, "cache", util.CacheLocation, "Path to the credential cache file.")
 
 	if len(os.Args) < 2 {
 		help(flagSet)

--- a/main.go
+++ b/main.go
@@ -18,10 +18,11 @@ import (
 	"flag"
 	"fmt"
 	"io/ioutil"
+	"os"
 	"strings"
+
 	"github.com/google/oauth2l/sgauth"
 	"github.com/google/oauth2l/util"
-	"os"
 )
 
 var (
@@ -30,9 +31,10 @@ var (
 	cmds        = []string{"fetch", "header", "info", "test"}
 )
 
-func help() {
-	fmt.Println("Usage: oauth2l {fetch|header|info|test|reset} " +
-		"[--jwt] [--json] [--sso] [--ssocli] {scope|aud|email}")
+func help(f *flag.FlagSet) {
+	fmt.Println("Usage: oauth2l fetch|header|info|test|reset [flags]... [scope|aud|email]...")
+	f.PrintDefaults()
+	os.Exit(0)
 }
 
 func readJSON(file string) (string, error) {
@@ -69,11 +71,6 @@ func parseScopes(scopes []string) string {
 }
 
 func main() {
-	if len(os.Args) < 2 {
-		help()
-		return
-	}
-
 	// Configure the CLI
 	flagSet := flag.NewFlagSet("fetch", flag.ExitOnError)
 	helpFlag := flagSet.Bool("help", false, "Print help message.")
@@ -85,11 +82,15 @@ func main() {
 	jwtFlag := flagSet.Bool("jwt", false, "Use JWT auth flow")
 	ssoFlag := flagSet.Bool("sso", false, "Use SSO auth flow")
 	ssocli := flagSet.String("ssocli", "", "Path to SSO CLI")
+
+	if len(os.Args) < 2 {
+		help(flagSet)
+	}
+
 	flagSet.Parse(os.Args[2:])
 
 	if *helpFlag {
-		help()
-		return
+		help(flagSet)
 	}
 
 	// Get the command keyword from the first argument.
@@ -128,9 +129,9 @@ func main() {
 				parseScopes(flagSet.Args()[1:]))
 		} else {
 			// OAuth flow
-			if (len(flagSet.Args()) < 1) {
-				fmt.Println("Missing scope for OAuth 2.0")
-				help()
+			if len(flagSet.Args()) < 1 {
+				fmt.Println("Missing scope argument for OAuth 2.0")
+				help(flagSet)
 				return
 			}
 
@@ -157,6 +158,6 @@ func main() {
 		util.Reset()
 	} else {
 		// Unknown command, print usage.
-		help()
+		help(flagSet)
 	}
 }

--- a/util/cache.go
+++ b/util/cache.go
@@ -16,11 +16,12 @@ package util
 
 import (
 	"encoding/json"
-	"github.com/google/oauth2l/sgauth"
 	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
+
+	"github.com/google/oauth2l/sgauth"
 )
 
 const CacheFileName = ".oauth2l"
@@ -40,6 +41,9 @@ type CacheKey struct {
 }
 
 func LookupCache(settings *sgauth.Settings) (*sgauth.Token, error) {
+	if CacheLocation == "" {
+		return nil, nil
+	}
 	var token sgauth.Token
 	var cache, err = loadCache()
 	if err != nil {
@@ -58,6 +62,9 @@ func LookupCache(settings *sgauth.Settings) (*sgauth.Token, error) {
 }
 
 func InsertCache(settings *sgauth.Settings, token *sgauth.Token) error {
+	if CacheLocation == "" {
+		return nil
+	}
 	var cache, err = loadCache()
 	if err != nil {
 		return err
@@ -79,6 +86,9 @@ func InsertCache(settings *sgauth.Settings, token *sgauth.Token) error {
 }
 
 func ClearCache() error {
+	if CacheLocation == "" {
+		return nil
+	}
 	if _, err := os.Stat(CacheLocation); os.IsNotExist(err) {
 		// Noop if file does not exist.
 		return nil
@@ -101,7 +111,7 @@ func loadCache() (map[string][]byte, error) {
 		log.Fatal(err)
 		return nil, err
 	}
-	m := map[string][]byte{}
+	m := make(map[string][]byte)
 	if len(data) > 0 {
 		err = json.Unmarshal(data, &m)
 		if err != nil {

--- a/util/cache.go
+++ b/util/cache.go
@@ -15,17 +15,17 @@
 package util
 
 import (
-	"log"
-	"io/ioutil"
 	"encoding/json"
-	"os"
 	"github.com/google/oauth2l/sgauth"
+	"io/ioutil"
+	"log"
+	"os"
 	"path/filepath"
 )
 
-const (
-	cacheFileName = ".oauth2l"
-)
+const CacheFileName = ".oauth2l"
+
+var CacheLocation string = filepath.Join(sgauth.GuessUnixHomeDir(), CacheFileName)
 
 // The key struct that used to identify an auth token fetch operation.
 type CacheKey struct {
@@ -75,28 +75,28 @@ func InsertCache(settings *sgauth.Settings, token *sgauth.Token) error {
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile(cacheLocation(), data, 0666)
+	return ioutil.WriteFile(CacheLocation, data, 0666)
 }
 
 func ClearCache() error {
-	if _, err := os.Stat(cacheLocation()); os.IsNotExist(err) {
+	if _, err := os.Stat(CacheLocation); os.IsNotExist(err) {
 		// Noop if file does not exist.
 		return nil
 	}
-	return os.Remove(cacheLocation())
+	return os.Remove(CacheLocation)
 }
 
 func loadCache() (map[string][]byte, error) {
-	if _, err := os.Stat(cacheLocation()); os.IsNotExist(err) {
+	if _, err := os.Stat(CacheLocation); os.IsNotExist(err) {
 		// Create the cache file if not existing.
-		f, err := os.OpenFile(cacheLocation(), os.O_RDONLY|os.O_CREATE, 0666)
+		f, err := os.OpenFile(CacheLocation, os.O_RDONLY|os.O_CREATE, 0666)
 		if err != nil {
 			log.Fatal(err)
 			return nil, err
 		}
 		f.Close()
 	}
-	data, err := ioutil.ReadFile(cacheLocation())
+	data, err := ioutil.ReadFile(CacheLocation)
 	if err != nil {
 		log.Fatal(err)
 		return nil, err
@@ -112,16 +112,11 @@ func loadCache() (map[string][]byte, error) {
 	return m, nil
 }
 
-func cacheLocation() string {
-	return filepath.Join(sgauth.GuessUnixHomeDir(), cacheFileName)
-}
-
 func createKey(settings *sgauth.Settings) CacheKey {
 	return CacheKey{
 		CredentialsJSON: settings.CredentialsJSON,
-		Scope: settings.Scope,
-		Audience: settings.Audience,
-		APIKey: settings.APIKey,
+		Scope:           settings.Scope,
+		Audience:        settings.Audience,
+		APIKey:          settings.APIKey,
 	}
 }
-


### PR DESCRIPTION
This change adds a new flag, --cache, that controls the cache file location and allows disabling caching.
This is useful when oauth2l is used in automated scripts, where caching can add unpredicability to the results, while at the same time allowing more fine-grained control than just "oauth2l reset".

This change also improves the help message by printing the defined flags descriptions and defaults directly from the flag.FlagSet.