### PR TITLE
Use exit code in addition of print for "test"

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,13 +177,15 @@ $ oauth2l info --token $(oauth2l fetch --scope pubsub)
 ### test
 
 Test a token. This sets an exit code of 0 for a valid token and 1 otherwise,
-which can be useful in shell pipelines.
+which can be useful in shell pipelines. It also prints the exit code.
 
 ```bash
 $ oauth2l test --token ya29.zyxwvutsrqpnmolkjihgfedcba
+0
 $ echo $?
 0
 $ oauth2l test --token ya29.justkiddingmadethisoneup
+1
 $ echo $?
 1
 ```

--- a/integration/cli_test.go
+++ b/integration/cli_test.go
@@ -205,7 +205,7 @@ func TestCLI(t *testing.T) {
 			"test; invalid token",
 			[]string{"test", "--token", "invalid-token"},
 			"test-invalid-token.golden",
-			false,
+			true,
 		},
 		{
 			"reset",

--- a/main.go
+++ b/main.go
@@ -250,7 +250,7 @@ func main() {
 	}
 
 	// Tasks that verify the existing token.
-	infoTasks := map[string]func(string){
+	infoTasks := map[string](func(string) int){
 		"info": util.Info,
 		"test": util.Test,
 	}
@@ -371,7 +371,7 @@ func main() {
 			}
 		}
 
-		task(token)
+		os.Exit(task(token))
 	} else if cmd == "reset" {
 		setCacheLocation(opts.Reset.Cache)
 		util.Reset()

--- a/util/tasks.go
+++ b/util/tasks.go
@@ -65,23 +65,26 @@ func Curl(settings *sgauth.Settings, args ...string) {
 }
 
 // Fetches the information of the given token.
-func Info(token string) {
+func Info(token string) int {
 	info, err := getTokenInfo(token)
 	if err != nil {
 		fmt.Print(err)
 	} else {
 		fmt.Println(info)
 	}
+	return 0
 }
 
 // Tests the given token. Returns 0 for valid tokens.
 // Otherwise returns 1.
-func Test(token string) {
+func Test(token string) int {
 	_, err := getTokenInfo(token)
 	if err != nil {
 		fmt.Println(1)
+		return 1
 	} else {
 		fmt.Println(0)
+		return 0
 	}
 }
 


### PR DESCRIPTION
The documentation mentions that "oauth2l test" returns 0 or 1, but the
current code prints the value instead of setting an exit code. This is
not useful for scripting.

This commit still keeps the printing part for backwards-compatibility
reasons.