### PR TITLE
Improve handling of expired access tokens in cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,6 +350,14 @@ Path to token cache file. Disables caching if set to empty (""). Defaults to ~/.
 $ oauth2l fetch --cache ~/different_path/.oauth2l --scope cloud-platform
 ```
 
+### --refresh
+
+If true, attempt to refresh expired access token (from the cache) using refresh token instead of re-authorizing.
+
+```bash
+$ oauth2l fetch --credentials ~/client_credentials.json --scope cloud-platform --refresh
+```
+
 ### fetch --output_format
 
 Token's output format for "fetch" command. One of bare, header, json, json_compact, pretty. Default is bare.

--- a/integration/cli_test.go
+++ b/integration/cli_test.go
@@ -262,6 +262,24 @@ func Test3LOFlow(t *testing.T) {
 			"fetch-3lo-cached.golden",
 			false,
 		},
+		{
+			"fetch; 3lo insert expired token into cache",
+			[]string{"fetch", "--scope", "pubsub", "--credentials", "integration/fixtures/fake-client-secrets-expired-token.json"},
+			"fetch-3lo.golden",
+			false,
+		},
+		{
+			"fetch; 3lo cached; token expired",
+			[]string{"fetch", "--scope", "pubsub", "--credentials", "integration/fixtures/fake-client-secrets-expired-token.json"},
+			"fetch-3lo.golden",
+			false,
+		},
+		{
+			"fetch; 3lo cached; refresh expired token",
+			[]string{"fetch", "--scope", "pubsub", "--credentials", "integration/fixtures/fake-client-secrets-expired-token.json", "--refresh"},
+			"fetch-3lo-cached.golden",
+			false,
+		},
 	}
 	runTestScenariosWithInput(t, tests, newFixture(t, "fake-verification-code.fixture").asFile())
 }
@@ -389,6 +407,12 @@ func MockTokenApi(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprint(w, response)
 }
 
+func MockExpiredTokenApi(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	response := readFile("integration/fixtures/mock-expired-token-response.json")
+	fmt.Fprint(w, response)
+}
+
 func MockCurlApi(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	response := "{}"
@@ -423,6 +447,7 @@ func TestMain(m *testing.M) {
 		mux := http.NewServeMux()
 		server := http.Server{Addr: ":8080", Handler: mux}
 		mux.HandleFunc("/token", MockTokenApi)
+		mux.HandleFunc("/expiredtoken", MockExpiredTokenApi)
 		mux.HandleFunc("/curl", MockCurlApi)
 		if err := server.ListenAndServe(); err != nil {
 			fmt.Printf("could not listen on port 8080 %v", err)

--- a/integration/fixtures/fake-client-secrets-expired-token.json
+++ b/integration/fixtures/fake-client-secrets-expired-token.json
@@ -1,0 +1,16 @@
+{
+  "installed": {
+    "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+    "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+    "client_email": "",
+    "client_id": "144169.apps.googleusercontent.com",
+    "project_id":"awesomeproject",
+    "client_secret": "awesomesecret",
+    "client_x509_cert_url": "",
+    "redirect_uris": [
+      "urn:ietf:wg:oauth:2.0:oob",
+      "http://localhost"
+    ],
+    "token_uri": "http://localhost:8080/expiredtoken"
+  }
+}

--- a/integration/fixtures/mock-expired-token-response.json
+++ b/integration/fixtures/mock-expired-token-response.json
@@ -1,0 +1,1 @@
+{"access_token": "ya29.GltDB_y4Oz8lVB5diZu9YVMgHuXoSVBXx6jt7WU9n8IaXk63RejERFtx2LfrH-VL51CbaAxKsC8EoMZXg50h2QvOcUQ-YZTvFnKtIJpLj_Zj68M56_VagXpZkZd7","expires_in": -1,"refresh_token": "1/q8uQkblGs0Zzpe1LtpDtBLKsyf_NlEnPOxo1DcTR27U","scope": "https://www.googleapis.com/auth/pubsub","token_type": "Bearer"}

--- a/main.go
+++ b/main.go
@@ -75,6 +75,9 @@ type commonFetchOptions struct {
 	// Cache is declared as a pointer type and can be one of nil, empty (""), or a custom file path.
 	Cache *string `long:"cache" description:"Path to the credential cache file. Disables caching if set to empty. Defaults to ~/.oauth2l."`
 
+	// Refresh is used for 3LO flow. When used in conjunction with caching, the user can avoid re-authorizing.
+	Refresh bool `long:"refresh" description:"If the cached access token is expired, attempt to refresh it using refreshToken."`
+
 	// Deprecated flags kept for backwards compatibility. Hidden from help page.
 	Json      string `long:"json" description:"Deprecated. Same as --credentials." hidden:"true"`
 	Jwt       bool   `long:"jwt" description:"Deprecated. Same as --type jwt." hidden:"true"`
@@ -256,6 +259,7 @@ func main() {
 		email := commonOpts.Email
 		ssocli := commonOpts.SsoCli
 		setCacheLocation(commonOpts.Cache)
+		refresh := commonOpts.Refresh
 		format := getOutputFormatWithFallback(opts.Fetch)
 		curlcli := opts.Curl.CurlCli
 		url := opts.Curl.Url
@@ -266,6 +270,7 @@ func main() {
 			Url:       url,
 			ExtraArgs: remainingArgs,
 			SsoCli:    ssocli,
+			Refresh:   refresh,
 		}
 
 		// Configure GUAC settings based on authType.

--- a/util/refresh.go
+++ b/util/refresh.go
@@ -1,0 +1,64 @@
+//
+// Copyright 2020 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package util
+
+import (
+	"encoding/json"
+
+	"github.com/google/oauth2l/sgauth/credentials"
+)
+
+type refreshCredentialsJSON struct {
+	ClientID     string `json:"client_id,omitempty"`
+	ClientSecret string `json:"client_secret,omitempty"`
+	TokenURL     string `json:"token_uri,omitempty"`
+	AuthURL      string `json:"auth_uri,omitempty"`
+	RefreshToken string `json:"refresh_token,omitempty"`
+	Type         string `json:"type,omitempty"`
+}
+
+// BuildRefreshCredentialsJSON attempts to construct a refreshCredentialsJSON
+// using a refreshToken and an OAuth Client ID credentialsJSON.
+// Empty string is returned if this is not possible.
+func BuildRefreshCredentialsJSON(refreshToken string, credentialsJSON string) string {
+	if refreshToken == "" {
+		return ""
+	}
+	var creds credentials.File
+	if err := json.Unmarshal([]byte(credentialsJSON), &creds); err != nil {
+		return ""
+	}
+	if creds.Type == credentials.ServiceAccountKey || creds.Type == credentials.UserCredentialsKey {
+		return ""
+	}
+	var oauth credentials.OAuthClient
+	if creds.Web.ProjectID != "" {
+		oauth = creds.Web
+	} else {
+		oauth = creds.Installed
+	}
+	if oauth.ClientID == "" || oauth.ClientSecret == "" {
+		return ""
+	}
+	var refreshCredentials refreshCredentialsJSON
+	refreshCredentials.ClientID = oauth.ClientID
+	refreshCredentials.ClientSecret = oauth.ClientSecret
+	refreshCredentials.TokenURL = oauth.TokenURL
+	refreshCredentials.AuthURL = oauth.AuthURL
+	refreshCredentials.RefreshToken = refreshToken
+	refreshCredentials.Type = credentials.UserCredentialsKey
+	refreshCredentialsJSON, _ := json.Marshal(refreshCredentials)
+	return string(refreshCredentialsJSON)
+}


### PR DESCRIPTION
1. Do not return expired access tokens from the cache to the user.
2. Automatically refresh expired access token via refresh token, if "refresh" option is enabled.