### PR TITLE
Install curl on image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,7 @@ RUN make build
 FROM alpine:latest
 RUN apk --no-cache add ca-certificates && \
   update-ca-certificates
+RUN apk --no-cache add curl
 
 COPY --from=builder /src/build/linux_amd64/oauth2l /bin/oauth2l
 ENTRYPOINT ["/bin/oauth2l"]


### PR DESCRIPTION
Install curl on image to allow `oauth2l` to use the curl subcommand to make requests authenticated with Google Auth.

Fixes #115 