### PR TITLE
Remove deprecated -i flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ deps:
 
 # dev installs the tool locally
 dev:
-	@go install -i ./...
+	@go install ./...
 .PHONY: dev
 
 # test runs the tests


### PR DESCRIPTION
Update dev rule from Makefile by removing the deprecated -i flag from the go install command.