### PR TITLE
Enabled 3LO loopback tests

### DIFF
--- a/integration/cli_test.go
+++ b/integration/cli_test.go
@@ -186,34 +186,7 @@ func runTestScenariosWithAdvancedLogic(t *testing.T, tests []testCase, input *os
 
 // Runs test cases where stdin input is needed and output needs to be processed before comparing to golden files.
 func runTestScenariosWithInputAndProcessedOutput(t *testing.T, tests []testCase, input *os.File, processOutput processOutput) {
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			cmd := exec.Command(binaryPath, tc.args...)
-			if input != nil {
-				cmd.Stdin = input
-			}
-
-			output, err := cmd.CombinedOutput()
-			if (err != nil) != tc.wantErr {
-				t.Fatalf("%s\nexpected (err != nil) to be %v, but got %v. err: %v", output, tc.wantErr, err != nil, err)
-			}
-			actual := string(output)
-
-			if processOutput != nil {
-				actual = processOutput(actual)
-			}
-
-			golden := newGoldenFile(t, tc.golden)
-
-			if *update {
-				golden.write(actual)
-			}
-			expected := golden.load()
-			if !reflect.DeepEqual(expected, actual) {
-				t.Fatalf("Expected: %v Actual: %v", expected, actual)
-			}
-		})
-	}
+	runTestScenariosWithAdvancedLogic(t, tests, input, processOutput, nil, nil)
 }
 
 // Helper for removing the randomly generated redirect uri's port from comparison.

--- a/integration/cli_test.go
+++ b/integration/cli_test.go
@@ -30,6 +30,7 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/oauth2l/util"
 )
@@ -473,6 +474,8 @@ func Test3LOLoopbackFlow(t *testing.T) {
 								}
 							}
 						}
+					} else {
+						time.Sleep(1 * time.Second)
 					}
 				}
 			}()

--- a/integration/cli_test.go
+++ b/integration/cli_test.go
@@ -109,7 +109,7 @@ func runTestScenarios(t *testing.T, tests []testCase) {
 
 // Runs test cases where stdin input is needed.
 func runTestScenariosWithInput(t *testing.T, tests []testCase, input *os.File) {
-	runTestScenariosWithInputAndProcessedOutput(t, tests, input, nil, nil, nil)
+	runTestScenariosWithInputAndProcessedOutput(t, tests, input, nil)
 }
 
 // Used for processing test output before comparing to golden files.
@@ -121,8 +121,8 @@ type preCommandLogic func(*testCase) error
 // Used for additional logic after executing oauth2l's command
 type postCommandLogic func(*testCase)
 
-// Runs test cases where stdin input is needed and output needs to be processed before comparing to golden files.
-func runTestScenariosWithInputAndProcessedOutput(t *testing.T, tests []testCase, input *os.File, processOutput processOutput,
+// Runs tests where extra logic needs to be added before and or after the command execution.
+func runTestScenariosWithAdvancedLogic(t *testing.T, tests []testCase, input *os.File, processOutput processOutput,
 	preCmdLogic preCommandLogic, postCmdLogic postCommandLogic) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -164,6 +164,11 @@ func runTestScenariosWithInputAndProcessedOutput(t *testing.T, tests []testCase,
 			}
 		})
 	}
+}
+
+// Runs test cases where stdin input is needed and output needs to be processed before comparing to golden files.
+func runTestScenariosWithInputAndProcessedOutput(t *testing.T, tests []testCase, input *os.File, processOutput processOutput) {
+	runTestScenariosWithAdvancedLogic(t, tests, input, processOutput, nil, nil)
 }
 
 // Helper for removing the randomly generated code_challenge string from comparison.
@@ -324,7 +329,7 @@ func Test3LOFlow(t *testing.T) {
 	process3LOOutput := func(output string) string {
 		return removeCodeChallenge(output)
 	}
-	runTestScenariosWithInputAndProcessedOutput(t, tests, newFixture(t, "fake-verification-code.fixture").asFile(), process3LOOutput, nil, nil)
+	runTestScenariosWithInputAndProcessedOutput(t, tests, newFixture(t, "fake-verification-code.fixture").asFile(), process3LOOutput)
 }
 
 // TODO: Enhance tests so that the entire loopback flow can be tested
@@ -496,7 +501,7 @@ func Test3LOLoopbackFlow(t *testing.T) {
 		return removeCodeChallenge(output)
 	}
 
-	runTestScenariosWithInputAndProcessedOutput(t, tests, nil, process3LOOutput, pre, post)
+	runTestScenariosWithAdvancedLogic(t, tests, nil, process3LOOutput, pre, post)
 }
 
 // Test OAuth 2LO Flow with fake service account.
@@ -564,7 +569,7 @@ func TestJWTFlow(t *testing.T) {
 		jsonString, _ := json.Marshal(jsonData)
 		return string(jsonString)
 	}
-	runTestScenariosWithInputAndProcessedOutput(t, tests, nil, processJwtOutput, nil, nil)
+	runTestScenariosWithInputAndProcessedOutput(t, tests, nil, processJwtOutput)
 }
 
 // Test SSO Flow. Uses "sh" to invoke fake ssocli to return a mock access token.
@@ -611,7 +616,7 @@ func TestStsFlow(t *testing.T) {
 		jsonString, _ := json.Marshal(jsonData)
 		return string(jsonString)
 	}
-	runTestScenariosWithInputAndProcessedOutput(t, tests, nil, processStsOutput, nil, nil)
+	runTestScenariosWithInputAndProcessedOutput(t, tests, nil, processStsOutput)
 }
 
 // Test Service Account Impersonation Flow.
@@ -636,7 +641,7 @@ func TestServiceAccountImpersonationFlow(t *testing.T) {
 		return string(jsonString)
 	}
 
-	runTestScenariosWithInputAndProcessedOutput(t, tests, nil, processOutput, nil, nil)
+	runTestScenariosWithInputAndProcessedOutput(t, tests, nil, processOutput)
 }
 
 func getCredentialsFileName(tc *testCase) string {

--- a/integration/cli_test.go
+++ b/integration/cli_test.go
@@ -172,6 +172,16 @@ func runTestScenariosWithInputAndProcessedOutput(t *testing.T, tests []testCase,
 	runTestScenariosWithAdvancedLogic(t, tests, input, processOutput, nil, nil)
 }
 
+// Helper for removing the randomly generated redirect uri's port from comparison.
+func removeRedirectUriPort(s string) string {
+	re := regexp.MustCompile("redirect_uri=.*http%3A%2F%2Flocalhost%3A\\d+")
+	match := re.FindString(s)
+	if match != "" {
+		return strings.Replace(s, match, "redirect_uri=http%3A%2F%2Flocalhost", 1)
+	}
+	return s
+}
+
 // Helper for removing the randomly generated code_challenge string from comparison.
 func removeCodeChallenge(s string) string {
 	re := regexp.MustCompile("code_challenge=.*code_challenge_method")
@@ -438,7 +448,7 @@ func Test3LOLoopbackFlow(t *testing.T) {
 			}
 			(*l).Close()
 
-			// searching for credentials
+			// searching for credentials filename.
 			f := getCredentialsFileName(tc)
 			if f == "" {
 				return fmt.Errorf("Credentials file is missing. Please add to test arguments.")
@@ -495,12 +505,7 @@ func Test3LOLoopbackFlow(t *testing.T) {
 	pre, post := loopbackLogic()
 
 	process3LOOutput := func(output string) string {
-		re := regexp.MustCompile("redirect_uri=http%3A%2F%2Flocalhost%3A\\d+")
-		match := re.FindString(output)
-		if match != "" {
-			output = strings.Replace(output, match, "redirect_uri=http%3A%2F%2Flocalhost", 1)
-		}
-		return removeCodeChallenge(output)
+		return removeCodeChallenge(removeRedirectUriPort(output))
 	}
 
 	runTestScenariosWithAdvancedLogic(t, tests, nil, process3LOOutput, pre, post)

--- a/integration/cli_test.go
+++ b/integration/cli_test.go
@@ -399,12 +399,20 @@ func Test3LOFlow(t *testing.T) {
 // Test OAuth 3LO loopback flow with fake client secrets. It does not wait for consent page interaction.
 // Instead a post request with the code and state is sent to the loopback server to advance the flow.
 func Test3LOLoopbackFlow(t *testing.T) {
+
+	const (
+		// NOTE: Update all consent page settings accordingly if one is changed.
+		CONSET_PAGE_TIMEOUT       = "30"
+		CONSET_PAGE_TIMEOUT_UNITS = "seconds"
+		CONSET_PAGE_DURATION      = time.Duration(30 * time.Second)
+	)
+
 	tests := []testCase{
 		{
 			"fetch; 3lo loopback",
 			[]string{"fetch", "--scope", "pubsub", "--credentials", "integration/fixtures/fake-client-secrets-3lo-loopback.json", "--cache", "",
 				"--disableAutoOpenConsentPage",
-				"--consentPageInteractionTimeout", "30", "--consentPageInteractionTimeoutUnits", "seconds"},
+				"--consentPageInteractionTimeout", CONSET_PAGE_TIMEOUT, "--consentPageInteractionTimeoutUnits", CONSET_PAGE_TIMEOUT_UNITS},
 			"fetch-3lo-loopback.golden",
 			false,
 		},
@@ -412,14 +420,14 @@ func Test3LOLoopbackFlow(t *testing.T) {
 			"fetch; 3lo loopback; old interface",
 			[]string{"fetch", "--json", "integration/fixtures/fake-client-secrets-3lo-loopback.json", "--cache", "", "pubsub",
 				"--disableAutoOpenConsentPage",
-				"--consentPageInteractionTimeout", "30", "--consentPageInteractionTimeoutUnits", "seconds"},
+				"--consentPageInteractionTimeout", CONSET_PAGE_TIMEOUT, "--consentPageInteractionTimeoutUnits", CONSET_PAGE_TIMEOUT_UNITS},
 			"fetch-3lo-loopback.golden",
 			false,
 		},
 		{
 			"fetch; 3lo loopback; userinfo scopes",
 			[]string{"fetch", "--scope", "userinfo.profile,userinfo.email", "--credentials", "integration/fixtures/fake-client-secrets-3lo-loopback.json", "--cache", "",
-				"--consentPageInteractionTimeout", "30", "--consentPageInteractionTimeoutUnits", "seconds",
+				"--consentPageInteractionTimeout", CONSET_PAGE_TIMEOUT, "--consentPageInteractionTimeoutUnits", CONSET_PAGE_TIMEOUT_UNITS,
 				"--disableAutoOpenConsentPage"},
 			"fetch-3lo-loopback-userinfo.golden",
 			false,
@@ -427,7 +435,7 @@ func Test3LOLoopbackFlow(t *testing.T) {
 		{
 			"header; 3lo loopback",
 			[]string{"header", "--scope", "pubsub", "--credentials", "integration/fixtures/fake-client-secrets-3lo-loopback.json", "--cache", "",
-				"--consentPageInteractionTimeout", "30", "--consentPageInteractionTimeoutUnits", "seconds",
+				"--consentPageInteractionTimeout", CONSET_PAGE_TIMEOUT, "--consentPageInteractionTimeoutUnits", CONSET_PAGE_TIMEOUT_UNITS,
 				"--disableAutoOpenConsentPage"},
 			"header-3lo-loopback.golden",
 			false,
@@ -435,7 +443,7 @@ func Test3LOLoopbackFlow(t *testing.T) {
 		{
 			"fetch; 3lo loopback; refresh token output format",
 			[]string{"fetch", "--output_format", "refresh_token", "--scope", "pubsub", "--credentials", "integration/fixtures/fake-client-secrets-3lo-loopback.json", "--cache", "",
-				"--consentPageInteractionTimeout", "30", "--consentPageInteractionTimeoutUnits", "seconds",
+				"--consentPageInteractionTimeout", CONSET_PAGE_TIMEOUT, "--consentPageInteractionTimeoutUnits", CONSET_PAGE_TIMEOUT_UNITS,
 				"--disableAutoOpenConsentPage"},
 			"fetch-3lo-loopback-refresh-token.golden",
 			false,
@@ -443,7 +451,7 @@ func Test3LOLoopbackFlow(t *testing.T) {
 		{
 			"curl; 3lo loopback",
 			[]string{"curl", "--scope", "pubsub", "--credentials", "integration/fixtures/fake-client-secrets-3lo-loopback.json", "--url", "http://localhost:8080/curl",
-				"--consentPageInteractionTimeout", "30", "--consentPageInteractionTimeoutUnits", "seconds",
+				"--consentPageInteractionTimeout", CONSET_PAGE_TIMEOUT, "--consentPageInteractionTimeoutUnits", CONSET_PAGE_TIMEOUT_UNITS,
 				"--disableAutoOpenConsentPage"},
 			"curl-3lo-loopback.golden",
 			false,
@@ -452,7 +460,7 @@ func Test3LOLoopbackFlow(t *testing.T) {
 			"fetch; 3lo loopback cached",
 			[]string{"fetch", "--scope", "pubsub", "--credentials", "integration/fixtures/fake-client-secrets-3lo-loopback.json",
 				"--disableAutoOpenConsentPage",
-				"--consentPageInteractionTimeout", "30", "--consentPageInteractionTimeoutUnits", "seconds"},
+				"--consentPageInteractionTimeout", CONSET_PAGE_TIMEOUT, "--consentPageInteractionTimeoutUnits", CONSET_PAGE_TIMEOUT_UNITS},
 			"fetch-3lo-cached.golden",
 			false,
 		},
@@ -460,7 +468,7 @@ func Test3LOLoopbackFlow(t *testing.T) {
 			"fetch; 3lo loopback insert expired token into cache",
 			[]string{"fetch", "--scope", "pubsub", "--credentials", "integration/fixtures/fake-client-secrets-expired-token-3lo-loopback.json",
 				"--disableAutoOpenConsentPage",
-				"--consentPageInteractionTimeout", "30", "--consentPageInteractionTimeoutUnits", "seconds"},
+				"--consentPageInteractionTimeout", CONSET_PAGE_TIMEOUT, "--consentPageInteractionTimeoutUnits", CONSET_PAGE_TIMEOUT_UNITS},
 			"fetch-3lo-loopback.golden",
 			false,
 		},
@@ -468,7 +476,7 @@ func Test3LOLoopbackFlow(t *testing.T) {
 			"fetch; 3lo loopback cached; token expired",
 			[]string{"fetch", "--scope", "pubsub", "--credentials", "integration/fixtures/fake-client-secrets-expired-token-3lo-loopback.json",
 				"--disableAutoOpenConsentPage",
-				"--consentPageInteractionTimeout", "30", "--consentPageInteractionTimeoutUnits", "seconds"},
+				"--consentPageInteractionTimeout", CONSET_PAGE_TIMEOUT, "--consentPageInteractionTimeoutUnits", CONSET_PAGE_TIMEOUT_UNITS},
 			"fetch-3lo-loopback.golden",
 			false,
 		},
@@ -476,7 +484,7 @@ func Test3LOLoopbackFlow(t *testing.T) {
 			"fetch; 3lo loopback cached; refresh expired token",
 			[]string{"fetch", "--scope", "pubsub", "--credentials", "integration/fixtures/fake-client-secrets-expired-token-3lo-loopback.json", "--refresh",
 				"--disableAutoOpenConsentPage",
-				"--consentPageInteractionTimeout", "30", "--consentPageInteractionTimeoutUnits", "seconds"},
+				"--consentPageInteractionTimeout", CONSET_PAGE_TIMEOUT, "--consentPageInteractionTimeoutUnits", CONSET_PAGE_TIMEOUT_UNITS},
 			"fetch-3lo-cached.golden",
 			false,
 		},
@@ -518,31 +526,30 @@ func Test3LOLoopbackFlow(t *testing.T) {
 			newContent := strings.Replace(fileContent, match, "\""+loopbackAddr+"\"", 1)
 			(*ll).cred.write(newContent)
 
-			// Triggering loopback logic: sends code and state message to
-			// the localhost server handling the authentication code - see loopback.go
-			// for more detials.
+			// Start loopback logic.
 			go func() {
+				timer := time.AfterFunc(CONSET_PAGE_DURATION, func() {
+					// Force ending the retry loop, so the retry logic does not loop
+					// forever. postLogic may trigger an end retry logic in case the
+					// exec. command finishes before the CONSET_PAGE_DURATION timeout.
+					(*ll).quitRetry = true
+				})
+				defer timer.Stop()
+
+				code_state_endpoint := loopbackAddr + CODE_AND_STATE
 				for (*ll).quitRetry != true {
-					url := loopbackAddr + util.SERVER_STATUS_ENDPOINT_URL
-					req, err := http.NewRequest("GET", url, nil)
+					req, err := http.NewRequest("POST", code_state_endpoint, nil)
 					if err == nil {
+						// Sending code and state message to the localhost server handling
+						// the authentication code - see loopback.go for more detials.
 						res, err := http.DefaultClient.Do(req)
 						if err == nil {
-							body, _ := ioutil.ReadAll(res.Body)
 							res.Body.Close()
-							if string(body) == "Status OK" {
-								url := loopbackAddr + CODE_AND_STATE
-								req, err := http.NewRequest("POST", url, nil)
-								if err == nil {
-									res, err := http.DefaultClient.Do(req)
-									if err == nil {
-										res.Body.Close()
-										(*ll).quitRetry = true
-									}
-								}
-							}
+							// Ending the retry loop
+							(*ll).quitRetry = true
 						}
 					} else {
+						// if unable to reach code_state_endpoint wait a second.
 						time.Sleep(1 * time.Second)
 					}
 				}
@@ -551,7 +558,9 @@ func Test3LOLoopbackFlow(t *testing.T) {
 		}
 
 		postLogic := func(loopbackAddr string) {
+			// End loopback logic if it is still retrying.
 			(*ll).quitRetry = true
+			// Removing temp credentials file.
 			os.Remove((*ll).cred.path())
 			return
 		}

--- a/integration/cli_test.go
+++ b/integration/cli_test.go
@@ -97,7 +97,7 @@ func (tf *testFile) load() string {
 }
 
 // saveAs saves the currect instance into another file in the same directory.
-// The current instance is not substituded by the newly create one.
+// The current instance is not substituted by the newly create one.
 //
 // input filename: is the new filename.
 func (tf *testFile) saveAs(filename string) {
@@ -402,9 +402,9 @@ func Test3LOLoopbackFlow(t *testing.T) {
 
 	const (
 		// NOTE: Update all consent page settings accordingly if one is changed.
-		CONSET_PAGE_TIMEOUT       = "30"
-		CONSET_PAGE_TIMEOUT_UNITS = "seconds"
-		CONSET_PAGE_DURATION      = time.Duration(30 * time.Second)
+		CONSENT_PAGE_TIMEOUT       = "30"
+		CONSENT_PAGE_TIMEOUT_UNITS = "seconds"
+		CONSENT_PAGE_DURATION      = time.Duration(30 * time.Second)
 	)
 
 	tests := []testCase{
@@ -412,7 +412,7 @@ func Test3LOLoopbackFlow(t *testing.T) {
 			"fetch; 3lo loopback",
 			[]string{"fetch", "--scope", "pubsub", "--credentials", "integration/fixtures/fake-client-secrets-3lo-loopback.json", "--cache", "",
 				"--disableAutoOpenConsentPage",
-				"--consentPageInteractionTimeout", CONSET_PAGE_TIMEOUT, "--consentPageInteractionTimeoutUnits", CONSET_PAGE_TIMEOUT_UNITS},
+				"--consentPageInteractionTimeout", CONSENT_PAGE_TIMEOUT, "--consentPageInteractionTimeoutUnits", CONSENT_PAGE_TIMEOUT_UNITS},
 			"fetch-3lo-loopback.golden",
 			false,
 		},
@@ -420,14 +420,14 @@ func Test3LOLoopbackFlow(t *testing.T) {
 			"fetch; 3lo loopback; old interface",
 			[]string{"fetch", "--json", "integration/fixtures/fake-client-secrets-3lo-loopback.json", "--cache", "", "pubsub",
 				"--disableAutoOpenConsentPage",
-				"--consentPageInteractionTimeout", CONSET_PAGE_TIMEOUT, "--consentPageInteractionTimeoutUnits", CONSET_PAGE_TIMEOUT_UNITS},
+				"--consentPageInteractionTimeout", CONSENT_PAGE_TIMEOUT, "--consentPageInteractionTimeoutUnits", CONSENT_PAGE_TIMEOUT_UNITS},
 			"fetch-3lo-loopback.golden",
 			false,
 		},
 		{
 			"fetch; 3lo loopback; userinfo scopes",
 			[]string{"fetch", "--scope", "userinfo.profile,userinfo.email", "--credentials", "integration/fixtures/fake-client-secrets-3lo-loopback.json", "--cache", "",
-				"--consentPageInteractionTimeout", CONSET_PAGE_TIMEOUT, "--consentPageInteractionTimeoutUnits", CONSET_PAGE_TIMEOUT_UNITS,
+				"--consentPageInteractionTimeout", CONSENT_PAGE_TIMEOUT, "--consentPageInteractionTimeoutUnits", CONSENT_PAGE_TIMEOUT_UNITS,
 				"--disableAutoOpenConsentPage"},
 			"fetch-3lo-loopback-userinfo.golden",
 			false,
@@ -435,7 +435,7 @@ func Test3LOLoopbackFlow(t *testing.T) {
 		{
 			"header; 3lo loopback",
 			[]string{"header", "--scope", "pubsub", "--credentials", "integration/fixtures/fake-client-secrets-3lo-loopback.json", "--cache", "",
-				"--consentPageInteractionTimeout", CONSET_PAGE_TIMEOUT, "--consentPageInteractionTimeoutUnits", CONSET_PAGE_TIMEOUT_UNITS,
+				"--consentPageInteractionTimeout", CONSENT_PAGE_TIMEOUT, "--consentPageInteractionTimeoutUnits", CONSENT_PAGE_TIMEOUT_UNITS,
 				"--disableAutoOpenConsentPage"},
 			"header-3lo-loopback.golden",
 			false,
@@ -443,7 +443,7 @@ func Test3LOLoopbackFlow(t *testing.T) {
 		{
 			"fetch; 3lo loopback; refresh token output format",
 			[]string{"fetch", "--output_format", "refresh_token", "--scope", "pubsub", "--credentials", "integration/fixtures/fake-client-secrets-3lo-loopback.json", "--cache", "",
-				"--consentPageInteractionTimeout", CONSET_PAGE_TIMEOUT, "--consentPageInteractionTimeoutUnits", CONSET_PAGE_TIMEOUT_UNITS,
+				"--consentPageInteractionTimeout", CONSENT_PAGE_TIMEOUT, "--consentPageInteractionTimeoutUnits", CONSENT_PAGE_TIMEOUT_UNITS,
 				"--disableAutoOpenConsentPage"},
 			"fetch-3lo-loopback-refresh-token.golden",
 			false,
@@ -451,7 +451,7 @@ func Test3LOLoopbackFlow(t *testing.T) {
 		{
 			"curl; 3lo loopback",
 			[]string{"curl", "--scope", "pubsub", "--credentials", "integration/fixtures/fake-client-secrets-3lo-loopback.json", "--url", "http://localhost:8080/curl",
-				"--consentPageInteractionTimeout", CONSET_PAGE_TIMEOUT, "--consentPageInteractionTimeoutUnits", CONSET_PAGE_TIMEOUT_UNITS,
+				"--consentPageInteractionTimeout", CONSENT_PAGE_TIMEOUT, "--consentPageInteractionTimeoutUnits", CONSENT_PAGE_TIMEOUT_UNITS,
 				"--disableAutoOpenConsentPage"},
 			"curl-3lo-loopback.golden",
 			false,
@@ -460,7 +460,7 @@ func Test3LOLoopbackFlow(t *testing.T) {
 			"fetch; 3lo loopback cached",
 			[]string{"fetch", "--scope", "pubsub", "--credentials", "integration/fixtures/fake-client-secrets-3lo-loopback.json",
 				"--disableAutoOpenConsentPage",
-				"--consentPageInteractionTimeout", CONSET_PAGE_TIMEOUT, "--consentPageInteractionTimeoutUnits", CONSET_PAGE_TIMEOUT_UNITS},
+				"--consentPageInteractionTimeout", CONSENT_PAGE_TIMEOUT, "--consentPageInteractionTimeoutUnits", CONSENT_PAGE_TIMEOUT_UNITS},
 			"fetch-3lo-cached.golden",
 			false,
 		},
@@ -468,7 +468,7 @@ func Test3LOLoopbackFlow(t *testing.T) {
 			"fetch; 3lo loopback insert expired token into cache",
 			[]string{"fetch", "--scope", "pubsub", "--credentials", "integration/fixtures/fake-client-secrets-expired-token-3lo-loopback.json",
 				"--disableAutoOpenConsentPage",
-				"--consentPageInteractionTimeout", CONSET_PAGE_TIMEOUT, "--consentPageInteractionTimeoutUnits", CONSET_PAGE_TIMEOUT_UNITS},
+				"--consentPageInteractionTimeout", CONSENT_PAGE_TIMEOUT, "--consentPageInteractionTimeoutUnits", CONSENT_PAGE_TIMEOUT_UNITS},
 			"fetch-3lo-loopback.golden",
 			false,
 		},
@@ -476,7 +476,7 @@ func Test3LOLoopbackFlow(t *testing.T) {
 			"fetch; 3lo loopback cached; token expired",
 			[]string{"fetch", "--scope", "pubsub", "--credentials", "integration/fixtures/fake-client-secrets-expired-token-3lo-loopback.json",
 				"--disableAutoOpenConsentPage",
-				"--consentPageInteractionTimeout", CONSET_PAGE_TIMEOUT, "--consentPageInteractionTimeoutUnits", CONSET_PAGE_TIMEOUT_UNITS},
+				"--consentPageInteractionTimeout", CONSENT_PAGE_TIMEOUT, "--consentPageInteractionTimeoutUnits", CONSENT_PAGE_TIMEOUT_UNITS},
 			"fetch-3lo-loopback.golden",
 			false,
 		},
@@ -484,7 +484,7 @@ func Test3LOLoopbackFlow(t *testing.T) {
 			"fetch; 3lo loopback cached; refresh expired token",
 			[]string{"fetch", "--scope", "pubsub", "--credentials", "integration/fixtures/fake-client-secrets-expired-token-3lo-loopback.json", "--refresh",
 				"--disableAutoOpenConsentPage",
-				"--consentPageInteractionTimeout", CONSET_PAGE_TIMEOUT, "--consentPageInteractionTimeoutUnits", CONSET_PAGE_TIMEOUT_UNITS},
+				"--consentPageInteractionTimeout", CONSENT_PAGE_TIMEOUT, "--consentPageInteractionTimeoutUnits", CONSENT_PAGE_TIMEOUT_UNITS},
 			"fetch-3lo-cached.golden",
 			false,
 		},
@@ -528,7 +528,7 @@ func Test3LOLoopbackFlow(t *testing.T) {
 
 			// Start loopback logic.
 			go func() {
-				timer := time.AfterFunc(CONSET_PAGE_DURATION, func() {
+				timer := time.AfterFunc(CONSENT_PAGE_DURATION, func() {
 					// Force ending the retry loop, so the retry logic does not loop
 					// forever. postLogic may trigger an end retry logic in case the
 					// exec. command finishes before the CONSET_PAGE_DURATION timeout.

--- a/integration/cli_test.go
+++ b/integration/cli_test.go
@@ -646,6 +646,10 @@ func TestServiceAccountImpersonationFlow(t *testing.T) {
 	runTestScenariosWithInputAndProcessedOutput(t, tests, nil, processOutput)
 }
 
+// getCredentialsFileName finds the credentials filename provided in the testCase argument.
+// If no filename is found, an empty string is returned.
+//
+// Note: the "--credentials" or "--json" options are used to find the credentials file.
 func getCredentialsFileName(tc *testCase) string {
 	var a string
 	var i int

--- a/integration/cli_test.go
+++ b/integration/cli_test.go
@@ -646,7 +646,7 @@ func TestServiceAccountImpersonationFlow(t *testing.T) {
 	runTestScenariosWithInputAndProcessedOutput(t, tests, nil, processOutput)
 }
 
-// getCredentialsFileName finds the credentials filename provided in the testCase argument.
+// getCredentialsFileName finds the credentials filename provided in the testCase arguments.
 // If no filename is found, an empty string is returned.
 //
 // Note: the "--credentials" or "--json" options are used to find the credentials file.

--- a/integration/cli_test.go
+++ b/integration/cli_test.go
@@ -115,10 +115,10 @@ func runTestScenariosWithInput(t *testing.T, tests []testCase, input *os.File) {
 // Used for processing test output before comparing to golden files.
 type processOutput func(string) string
 
-// Used for added logic before executing oauth2l's command
+// Used for additional logic before executing oauth2l's command
 type preCommandLogic func(*testCase) error
 
-// Used for added logic before executing oauth2l's command
+// Used for additional logic after executing oauth2l's command
 type postCommandLogic func(*testCase)
 
 // Runs test cases where stdin input is needed and output needs to be processed before comparing to golden files.

--- a/integration/cli_test.go
+++ b/integration/cli_test.go
@@ -121,7 +121,7 @@ type preCommandLogic func(*testCase) error
 // Used for additional logic after executing oauth2l's command
 type postCommandLogic func(*testCase)
 
-// Runs tests where extra logic needs to be added before and or after the command execution.
+// Runs tests where extra logic needs to be added before and/or after the command execution.
 func runTestScenariosWithAdvancedLogic(t *testing.T, tests []testCase, input *os.File, processOutput processOutput,
 	preCmdLogic preCommandLogic, postCmdLogic postCommandLogic) {
 	for _, tc := range tests {
@@ -332,10 +332,9 @@ func Test3LOFlow(t *testing.T) {
 	runTestScenariosWithInputAndProcessedOutput(t, tests, newFixture(t, "fake-verification-code.fixture").asFile(), process3LOOutput)
 }
 
-// TODO: Enhance tests so that the entire loopback flow can be tested
-// TODO: Once enhanced, uncomment and fix cache tests in this flow
 // TODO: Remove Test3LOFlow once the 3LO flow is deprecated
-// Test OAuth 3LO loopback flow with fake client secrets. Stops waiting for consent page interaction to advance the flow.
+// Test OAuth 3LO loopback flow with fake client secrets. It does not wait for consent page interaction.
+// Instead a post request with the code and state is sent to the loopback server to advance the flow.
 func Test3LOLoopbackFlow(t *testing.T) {
 	tests := []testCase{
 		{

--- a/integration/cli_test.go
+++ b/integration/cli_test.go
@@ -123,12 +123,12 @@ type postCommandLogic func(*testCase)
 
 // Runs test cases where stdin input is needed and output needs to be processed before comparing to golden files.
 func runTestScenariosWithInputAndProcessedOutput(t *testing.T, tests []testCase, input *os.File, processOutput processOutput,
-	preComndLogic preCommandLogic, postComndLogic postCommandLogic) {
+	preCmdLogic preCommandLogic, postCmdLogic postCommandLogic) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			// Processing logic before exec.Command
-			if preComndLogic != nil {
-				if err := preComndLogic(&tc); err != nil {
+			if preCmdLogic != nil {
+				if err := preCmdLogic(&tc); err != nil {
 					t.Fatalf("Unexpected error: %v", err)
 				}
 			}
@@ -140,8 +140,8 @@ func runTestScenariosWithInputAndProcessedOutput(t *testing.T, tests []testCase,
 
 			output, err := cmd.CombinedOutput()
 			// Processing logic after exec.Command
-			if postComndLogic != nil {
-				postComndLogic(&tc)
+			if postCmdLogic != nil {
+				postCmdLogic(&tc)
 			}
 
 			if (err != nil) != tc.wantErr {

--- a/integration/cli_test.go
+++ b/integration/cli_test.go
@@ -542,7 +542,7 @@ func Test3LOLoopbackFlow(t *testing.T) {
 		postLogic := func() {
 			// End loopback logic if it is still retrying:
 			// In the event where exec Command exits prematurely, the loopback loop
-			// should not try to POST the code and state. It will only waste resources.
+			// should not try to POST the code and state - It would only waste resources.
 			(*ll).quitRetry = true
 			// Removing temp credentials file.
 			os.Remove((*ll).cred.path())

--- a/integration/cli_test.go
+++ b/integration/cli_test.go
@@ -450,7 +450,7 @@ func Test3LOLoopbackFlow(t *testing.T) {
 			// Triggering loopback logic
 			go func() {
 				for (*ll).quit != true {
-					url := a + "/status/get"
+					url := a + util.SERVER_STATUS_ENDPOINT_URL
 					req, err := http.NewRequest("GET", url, nil)
 					if err == nil {
 						res, err := http.DefaultClient.Do(req)

--- a/integration/fixtures/fake-client-secrets-3lo-loopback.json
+++ b/integration/fixtures/fake-client-secrets-3lo-loopback.json
@@ -2,7 +2,7 @@
   "installed": {
     "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
     "auth_uri": "https://accounts.google.com/o/oauth2/auth",
-    "client_email": " ",
+    "client_email": "force-cache-diff",
     "client_id": "144169.apps.googleusercontent.com",
     "project_id":"awesomeproject",
     "client_secret": "awesomesecret",

--- a/integration/fixtures/fake-client-secrets-3lo-loopback.json
+++ b/integration/fixtures/fake-client-secrets-3lo-loopback.json
@@ -2,7 +2,7 @@
   "installed": {
     "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
     "auth_uri": "https://accounts.google.com/o/oauth2/auth",
-    "client_email": "force-cache-diff",
+    "client_email": "loopback-test@gmail.com",
     "client_id": "144169.apps.googleusercontent.com",
     "project_id":"awesomeproject",
     "client_secret": "awesomesecret",

--- a/integration/fixtures/fake-client-secrets-expired-token-3lo-loopback.json
+++ b/integration/fixtures/fake-client-secrets-expired-token-3lo-loopback.json
@@ -2,7 +2,7 @@
   "installed": {
     "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
     "auth_uri": "https://accounts.google.com/o/oauth2/auth",
-    "client_email": "",
+    "client_email": "loopback-test@gmail.com",
     "client_id": "144169.apps.googleusercontent.com",
     "project_id":"awesomeproject",
     "client_secret": "awesomesecret",

--- a/integration/fixtures/fake-client-secrets-expired-token-3lo-loopback.json
+++ b/integration/fixtures/fake-client-secrets-expired-token-3lo-loopback.json
@@ -2,7 +2,7 @@
   "installed": {
     "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
     "auth_uri": "https://accounts.google.com/o/oauth2/auth",
-    "client_email": " ",
+    "client_email": "",
     "client_id": "144169.apps.googleusercontent.com",
     "project_id":"awesomeproject",
     "client_secret": "awesomesecret",
@@ -11,6 +11,6 @@
       "http://localhost",
       "urn:ietf:wg:oauth:2.0:oob"
     ],
-    "token_uri": "http://localhost:8080/token"
+    "token_uri": "http://localhost:8080/expiredtoken"
   }
 }

--- a/integration/fixtures/fake-client-secrets-expired-token.json
+++ b/integration/fixtures/fake-client-secrets-expired-token.json
@@ -2,7 +2,7 @@
   "installed": {
     "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
     "auth_uri": "https://accounts.google.com/o/oauth2/auth",
-    "client_email": "",
+    "client_email": "test@gmail.com",
     "client_id": "144169.apps.googleusercontent.com",
     "project_id":"awesomeproject",
     "client_secret": "awesomesecret",

--- a/integration/fixtures/fake-client-secrets.json
+++ b/integration/fixtures/fake-client-secrets.json
@@ -2,7 +2,7 @@
   "installed": {
     "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
     "auth_uri": "https://accounts.google.com/o/oauth2/auth",
-    "client_email": "",
+    "client_email": "test@gmail.com",
     "client_id": "144169.apps.googleusercontent.com",
     "project_id":"awesomeproject",
     "client_secret": "awesomesecret",

--- a/integration/golden/curl-3lo-loopback.golden
+++ b/integration/golden/curl-3lo-loopback.golden
@@ -1,4 +1,4 @@
 Go to the following link in your browser:
 
  https://accounts.google.com/o/oauth2/auth?client_id=144169.apps.googleusercontent.com&code_challenge_method=S256&redirect_uri=http%3A%2F%2Flocalhost&response_type=code&scope=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fpubsub&state=state
-Authorization code not yet set.
+{}

--- a/integration/golden/fetch-3lo-loopback-refresh-token.golden
+++ b/integration/golden/fetch-3lo-loopback-refresh-token.golden
@@ -1,4 +1,4 @@
 Go to the following link in your browser:
 
  https://accounts.google.com/o/oauth2/auth?client_id=144169.apps.googleusercontent.com&code_challenge_method=S256&redirect_uri=http%3A%2F%2Flocalhost&response_type=code&scope=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fpubsub&state=state
-Authorization code not yet set.
+{"client_id":"144169.apps.googleusercontent.com","client_secret":"awesomesecret","token_uri":"http://localhost:8080/token","auth_uri":"https://accounts.google.com/o/oauth2/auth","refresh_token":"1/q8uQkblGs0Zzpe1LtpDtBLKsyf_NlEnPOxo1DcTR27U","type":"authorized_user"}

--- a/integration/golden/fetch-3lo-loopback-userinfo.golden
+++ b/integration/golden/fetch-3lo-loopback-userinfo.golden
@@ -1,4 +1,4 @@
 Go to the following link in your browser:
 
  https://accounts.google.com/o/oauth2/auth?client_id=144169.apps.googleusercontent.com&code_challenge_method=S256&redirect_uri=http%3A%2F%2Flocalhost&response_type=code&scope=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fuserinfo.profile+https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fuserinfo.email&state=state
-Authorization code not yet set.
+ya29.GltDB_y4Oz8lVB5diZu9YVMgHuXoSVBXx6jt7WU9n8IaXk63RejERFtx2LfrH-VL51CbaAxKsC8EoMZXg50h2QvOcUQ-YZTvFnKtIJpLj_Zj68M56_VagXpZkZd7

--- a/integration/golden/fetch-3lo-loopback.golden
+++ b/integration/golden/fetch-3lo-loopback.golden
@@ -1,4 +1,4 @@
 Go to the following link in your browser:
 
  https://accounts.google.com/o/oauth2/auth?client_id=144169.apps.googleusercontent.com&code_challenge_method=S256&redirect_uri=http%3A%2F%2Flocalhost&response_type=code&scope=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fpubsub&state=state
-Authorization code not yet set.
+ya29.GltDB_y4Oz8lVB5diZu9YVMgHuXoSVBXx6jt7WU9n8IaXk63RejERFtx2LfrH-VL51CbaAxKsC8EoMZXg50h2QvOcUQ-YZTvFnKtIJpLj_Zj68M56_VagXpZkZd7

--- a/integration/golden/header-3lo-loopback.golden
+++ b/integration/golden/header-3lo-loopback.golden
@@ -1,4 +1,4 @@
 Go to the following link in your browser:
 
  https://accounts.google.com/o/oauth2/auth?client_id=144169.apps.googleusercontent.com&code_challenge_method=S256&redirect_uri=http%3A%2F%2Flocalhost&response_type=code&scope=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fpubsub&state=state
-Authorization code not yet set.
+Authorization: Bearer ya29.GltDB_y4Oz8lVB5diZu9YVMgHuXoSVBXx6jt7WU9n8IaXk63RejERFtx2LfrH-VL51CbaAxKsC8EoMZXg50h2QvOcUQ-YZTvFnKtIJpLj_Zj68M56_VagXpZkZd7

--- a/util/cache.go
+++ b/util/cache.go
@@ -132,7 +132,7 @@ func createKey(settings *Settings) CacheKey {
 	// Removing redirect_uri from credentials file. This allows for dynamic
 	// localhost ports created during 3LO loopback.
 	var credentialsJSON string = settings.CredentialsJSON
-	re := regexp.MustCompile("\"redirect_uris\":\\[(.*?)\\]")
+	re := regexp.MustCompile("\"redirect_uris\":([[:graph:]\\s]*?)\\]")
 	match := re.FindString(credentialsJSON)
 	credentialsJSON = strings.Replace(credentialsJSON, match, "\"redirect_uris\":[]", 1)
 

--- a/util/loopback.go
+++ b/util/loopback.go
@@ -122,7 +122,7 @@ type AuthorizationCodeLocalhost struct {
 }
 
 func (lh *AuthorizationCodeLocalhost) ListenAndServe(address string) (serverAddress string, err error) {
-	listener, serverAddress, err := getListener(address)
+	listener, serverAddress, err := GetListener(address)
 	if err != nil {
 		return "", fmt.Errorf("Unable to Listen: %v", err)
 	}
@@ -293,7 +293,7 @@ func (lh *AuthorizationCodeLocalhost) statusGetHandler(w http.ResponseWriter, r 
 	return
 }
 
-// getListener gets a listener on the port specified in the address.
+// GetListener gets a listener on the port specified in the address.
 // If no port is specified in the address, an available port is assigned.
 //
 // Input address: represents a localhost address. Its format is http://localhost[:port]
@@ -301,7 +301,7 @@ func (lh *AuthorizationCodeLocalhost) statusGetHandler(w http.ResponseWriter, r 
 // Returns listener
 // Returns serverAddress: is the address of the listener. Its format is http://localhost[:port]
 // Returns err: if not nil an error occurred when creating the listener.
-func getListener(address string) (listener *net.Listener, serverAddress string, err error) {
+func GetListener(address string) (listener *net.Listener, serverAddress string, err error) {
 	var l net.Listener = nil
 
 	re := regexp.MustCompile("localhost:\\d+")

--- a/util/loopback.go
+++ b/util/loopback.go
@@ -28,6 +28,12 @@ import (
 	"time"
 )
 
+// Loopback server endpoints
+const (
+	SERVER_STATUS_ENDPOINT_URL   = "/status/get"
+	SERVER_LOOPBACK_ENDPOINT_URL = "/"
+)
+
 type AuthorizationCodeRequestStatus int
 
 // Phases of the authorization code
@@ -132,8 +138,8 @@ func (lh *AuthorizationCodeLocalhost) ListenAndServe(address string) (serverAddr
 	// Setup local host in given address
 	mux := http.NewServeMux()
 	lh.server = &http.Server{Addr: strings.Replace(lh.addr, "http://", "", 1), Handler: mux}
-	mux.HandleFunc("/", lh.redirectUriHandler)
-	mux.HandleFunc("/status/get", lh.statusGetHandler)
+	mux.HandleFunc(SERVER_LOOPBACK_ENDPOINT_URL, lh.redirectUriHandler)
+	mux.HandleFunc(SERVER_STATUS_ENDPOINT_URL, lh.statusGetHandler)
 
 	go func() {
 		// Start Listed and Serve


### PR DESCRIPTION
Hi Andy,

3LO loopback testing is complete - all tests are passing!

FYI: 
I found some bugs in the cache that were a little difficult to debug. In summary, the cache key was not working. Mainly because the regex exp did not take into account new lines. The credentials file provided in the tests consisted of multiple lines. In contrast, the file provided by GCP had a single line. (see further notes below)

TODO:
I tried to split the test file into multiple, but there are many technicalities that kept me from it. I think that should be a task of its own and did not want to make it part of this commit. 

Please let me know if you have any further questions. As always, I tried to make the code as readable as possible!

Thanks for reviewing,
Ulises