### PR TITLE
chore: Update Makefile to support arm64 for darwin and linux (syntax fix 2)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ build:
 			SUFFIX=""; \
 			GOARCHES_SUPPORTED="${GOARCHES}"; \
 		fi ; \
-		for GOARCH in ${GOARCHES_SUPPORTED}; do \
+		for GOARCH in $${GOARCHES_SUPPORTED}; do \
 			echo "Building $${GOOS}/$${GOARCH}" ; \
 			GOOS=$${GOOS} GOARCH=$${GOARCH} go build \
 				-a \


### PR DESCRIPTION
requires double "$" when referencing temp variables.