### PR TITLE
Upgrade Go version to 1.26 and fix fmt.Errorf format string issue

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: 1.23
+        go-version: 1.26
 
     - name: Build
       run: go build -v ./...

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.24 AS builder
+FROM golang:1.26 AS builder
 
 ENV GO111MODULE=on \
   CGO_ENABLED=0 \

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -14,18 +14,18 @@
 
 steps:
 - id: test
-  name: golang:1.23
+  name: golang:1.26
   entrypoint: make
   args: ['test']
 
 - id: build
-  name: golang:1.23
+  name: golang:1.26
   entrypoint: make
   args: ['build']
   waitFor: ['test']
 
 - id: compress
-  name: golang:1.23
+  name: golang:1.26
   entrypoint: make
   args: ['compress']
   waitFor: ['build']

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/google/oauth2l
 
-go 1.23
+go 1.26
 
-toolchain go1.24.0
+toolchain go1.26.4
 
 require (
 	github.com/google/uuid v1.6.0

--- a/util/loopback.go
+++ b/util/loopback.go
@@ -197,7 +197,7 @@ func (lh *AuthorizationCodeLocalhost) WaitForListeningAndServing(maxWaitTime tim
 
 func (lh *AuthorizationCodeLocalhost) GetAuthenticationCode() (authCode AuthorizationCode, err error) {
 	if lh.AuthCodeReqStatus.Status != GRANTED {
-		return lh.authCode, fmt.Errorf(lh.AuthCodeReqStatus.Details)
+		return lh.authCode, fmt.Errorf("%s", lh.AuthCodeReqStatus.Details)
 	}
 	return lh.authCode, nil
 }


### PR DESCRIPTION
`go vet` is stricter in go 1.26 requiring change in string format syntax for unit tests to pass